### PR TITLE
Hyun response tokens

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,7 +153,6 @@ if __name__ == "__main__":
     parser.add_argument("--test", default=False, action="store_true")
     args = parser.parse_args()
 
-    args.test = True
     if args.test:
         _test(args.seed)
         exit(1)

--- a/model.py
+++ b/model.py
@@ -61,6 +61,7 @@ class MetaLinguisticJudgement:
 
         tokenizer = self.llm.get_tokenizer()
         yes_token_id = tokenizer(" Yes")["input_ids"][-1]
+        # yes_token_ids = [t[-1] for t in tokenizer.batch_encode_plus([" Yes", "yes", "Yes", " yes"])["input_ids"]]
         no_token_id = tokenizer(" No")["input_ids"][-1]
         a_token_id = tokenizer(" A")["input_ids"][-1]
         b_token_id = tokenizer(" B")["input_ids"][-1]


### PR DESCRIPTION
Modified collation logic to take first output token, rather than first orthographic word. 

For Llama models at least, only _Yes tokens and _No tokens occur. Yes, _yes, yes, No, _no, and no tokens do not occur and appear to have trivial probabilities, which does not warrant 4-6x our compute time for token logprob estimation, IMO.
My initial concern was whether _Yes, or _No, were tokens, but the comma its tokenized separately.

So, not much is changed, other than the first output token retrieval process.

