### PR TITLE
Fix prompt typos, set temp=0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,10 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# manual analysis files
+*.xlsx
+runs-*/*
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/model.py
+++ b/model.py
@@ -8,12 +8,12 @@ class MetaLinguisticJudgement:
     def __init__(self, model_name, seed, max_model_len=216):
         self.model_name = model_name
         self.infer_params = SamplingParams(
-            temperature=0.8,
+            temperature=0,
             top_p=0.95,
             max_tokens=64,
             seed=seed)
         self.logprob_params = SamplingParams(
-            temperature=0.8,
+            temperature=0,
             top_p=0.95,
             max_tokens=1,
             seed=seed,

--- a/prompts.py
+++ b/prompts.py
@@ -134,7 +134,7 @@ def coverage_binary_question_negation(contract):
     # list for HF
     return f"""{contract['header']}
 {contract['continuation']}
-{locus_premise(contract['locus_of_uncertainty'])}, {is_person_not_covered_question(contract['person_name'])}? {YES_NO_QUESTION}"""
+{locus_premise(contract['locus_of_uncertainty'])}, {is_person_not_covered_question(contract['person_name'])} {YES_NO_QUESTION}"""
 
 def coverage_agreement(contract):
     return f"""{contract['header']}

--- a/prompts.py
+++ b/prompts.py
@@ -112,7 +112,7 @@ def coverage_binary_question(binary_question_suffix, contract):
     # list for HF
     return f"""{contract['header']}
 {contract['continuation']}
-{locus_premise(contract['locus_of_uncertainty'])}, {is_person_covered_question(contract['person_name'])}? {binary_question_suffix}"""
+{locus_premise(contract['locus_of_uncertainty'])}, {is_person_covered_question(contract['person_name'])} {binary_question_suffix}"""
 
 
 ANSWER_TRIGGER="Final answer is:"
@@ -139,25 +139,25 @@ def coverage_binary_question_negation(contract):
 def coverage_agreement(contract):
     return f"""{contract['header']}
     {contract['continuation']}
-    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is covered by the insurance. Do you agree? {YES_NO_QUESTION} {ANSWER_TRIGGER}"""
+    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is covered by the insurance. Do you agree? {YES_NO_QUESTION}"""
 
 
 def coverage_agreement_on_negation(contract):
     return f"""{contract['header']}
     {contract['continuation']}
-    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is not covered by the insurance. Do you agree? {YES_NO_QUESTION} {ANSWER_TRIGGER}"""
+    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is not covered by the insurance. Do you agree? {YES_NO_QUESTION}"""
 
 
 def coverage_disagreement(contract):
     return f"""{contract['header']}
     {contract['continuation']}
-    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is covered by the insurance. Do you disagree? {YES_NO_QUESTION} {ANSWER_TRIGGER}"""
+    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is covered by the insurance. Do you disagree? {YES_NO_QUESTION}"""
 
 
 def coverage_disagreement_on_negation(contract):
     return f"""{contract['header']}
     {contract['continuation']}
-    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is not covered by the insurance. Do you disagree? {YES_NO_QUESTION} {ANSWER_TRIGGER}"""
+    {locus_premise(contract['locus_of_uncertainty'])}, {contract['person_name']} is not covered by the insurance. Do you disagree? {YES_NO_QUESTION}"""
 
 
 def coverage_options(contract):


### PR DESCRIPTION
* Remove duplicate triggers (cues) and question marks
* Set temperature to 0 to align response token with logprob distribution